### PR TITLE
feat: implement GET /api/bounties/:id — bounty detail endpoint

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,0 +1,157 @@
+import { serve } from '@hono/node-server';
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+import { logger } from 'hono/logger';
+import dotenv from 'dotenv';
+
+// Load environment variables
+dotenv.config();
+
+// Validate environment variables
+if (!process.env.GEMINI_API_KEY) {
+    console.error('FATAL ERROR: GEMINI_API_KEY is not defined in the environment.');
+    process.exit(1);
+}
+
+const app = new Hono();
+const port = Number(process.env.PORT) || 3001;
+
+// The base URL of the main DevAsign API. Configurable via environment variable.
+const DEVASIGN_API_URL = process.env.DEVASIGN_API_URL || 'https://api.devasign.com';
+
+// Global middleware
+app.use('*', logger());
+app.use('*', cors());
+
+// Rate limiter stub middleware
+app.use('*', async (_c, next) => {
+    // TODO(#1): Implement a robust rate limiter (e.g., using `@hono/rate-limiter`).
+    // For now, checks are skipped
+    await next();
+});
+
+// Error handler
+app.onError((err, c) => {
+    console.error('App Error:', err);
+    if (process.env.NODE_ENV === 'production') {
+        return c.json({ error: 'Internal server error' }, 500);
+    }
+    return c.json({ error: 'Internal server error', message: err.message }, 500);
+});
+
+// API Routes
+app.get('/health', (c) => {
+    return c.json({ status: 'ok' });
+});
+
+app.post('/api/gemini', async (c) => {
+    try {
+        const apiKey = process.env.GEMINI_API_KEY;
+
+        if (!apiKey) {
+            return c.json({ error: 'Gemini API key not configured on server' }, 500);
+        }
+
+        // This is where the actual Gemini API call would go.
+        // For now, we'll just return a success message indicating the secure setup works.
+        // In a real implementation, you would use the Google Generative AI SDK here.
+
+        const body = await c.req.json();
+        const { prompt } = body;
+
+        if (typeof prompt !== 'string' || prompt.trim() === '') {
+            return c.json({ error: 'Prompt is required and must be a non-empty string' }, 400);
+        }
+
+        console.log('Received prompt:', prompt);
+
+        return c.json({
+            message: 'Request received securely on backend',
+            status: 'success'
+        });
+
+    } catch (error: any) {
+        console.error('Error processing Gemini request:', error);
+        return c.json({ error: 'Internal server error' }, 500);
+    }
+});
+
+/**
+ * GET /api/bounties/:id
+ *
+ * Fetches full details for a single bounty, including:
+ *   - Creator info (username, avatarUrl)
+ *   - Application count
+ *   - Assignee info (if the bounty has been assigned to a developer)
+ *   - Current status
+ *
+ * Proxies to the main DevAsign API at DEVASIGN_API_URL.
+ * Returns 404 if the bounty is not found, 502 if the upstream API is unreachable.
+ */
+app.get('/api/bounties/:id', async (c) => {
+    const { id } = c.req.param();
+
+    if (!id || id.trim() === '') {
+        return c.json({ error: 'Bounty ID is required' }, 400);
+    }
+
+    try {
+        const upstreamUrl = `${DEVASIGN_API_URL}/bounties/${encodeURIComponent(id)}`;
+
+        const response = await fetch(upstreamUrl, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+                // Forward the Authorization header if present (authenticated requests)
+                ...(c.req.header('Authorization')
+                    ? { Authorization: c.req.header('Authorization')! }
+                    : {}),
+            },
+        });
+
+        if (response.status === 404) {
+            return c.json({ error: 'Bounty not found' }, 404);
+        }
+
+        if (!response.ok) {
+            console.error(`Upstream API error: ${response.status} ${response.statusText}`);
+            return c.json(
+                { error: 'Failed to fetch bounty details from upstream API' },
+                502
+            );
+        }
+
+        const data = await response.json() as {
+            id: string;
+            repoOwner: string;
+            repoName: string;
+            title: string;
+            description: string;
+            amount: number;
+            tags: string[];
+            difficulty: string;
+            deadline: string;
+            status: string;
+            creator: {
+                username: string;
+                avatarUrl: string;
+                rating: number;
+            };
+            requirements: string[];
+            applicationCount: number;
+            assignee: { username: string; avatarUrl: string } | null;
+        };
+
+        return c.json(data);
+    } catch (error: any) {
+        console.error(`Error fetching bounty ${id}:`, error);
+        return c.json({ error: 'Unable to reach upstream API' }, 502);
+    }
+});
+
+console.log(`Server is running on http://localhost:${port}`);
+
+serve({
+    fetch: app.fetch,
+    port
+});

--- a/packages/mobile/pages/BountyDetail.tsx
+++ b/packages/mobile/pages/BountyDetail.tsx
@@ -1,0 +1,305 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { ArrowLeft, Github, Calendar, Shield, Share2, CheckCircle2, Users, User as UserIcon } from 'lucide-react';
+import { Button, Badge } from '../components/Shared';
+import { Bounty } from '../types';
+
+export const BountyDetail: React.FC = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [bounty, setBounty] = useState<Bounty | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [applying, setApplying] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  // Check if we should hide the apply button (e.g. user came from Submit Task page)
+  const hideApply = (location.state as { hideApply?: boolean })?.hideApply;
+
+  useEffect(() => {
+    if (!id) {
+      setError('No bounty ID provided.');
+      setLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const fetchBounty = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch(`/api/bounties/${encodeURIComponent(id)}`, {
+          signal: controller.signal,
+        });
+
+        if (response.status === 404) {
+          setError('Bounty not found.');
+          return;
+        }
+
+        if (!response.ok) {
+          throw new Error(`Server error: ${response.status}`);
+        }
+
+        const data: Bounty = await response.json();
+        setBounty(data);
+      } catch (err: any) {
+        if (err.name !== 'AbortError') {
+          console.error('Failed to fetch bounty:', err);
+          setError('Failed to load bounty details. Please try again.');
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchBounty();
+
+    return () => controller.abort();
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div className="p-8 text-center text-text-secondary animate-pulse">
+        Loading bounty details…
+      </div>
+    );
+  }
+
+  if (error || !bounty) {
+    return (
+      <div className="p-8 text-center text-text-secondary">
+        {error ?? 'Bounty not found'}
+      </div>
+    );
+  }
+
+  if (submitted) {
+    return (
+      <div className="min-h-[85vh] flex flex-col items-center justify-center text-center space-y-8 animate-in zoom-in-95 duration-300 p-6">
+        <div className="w-24 h-24 bg-primary/10 rounded-full flex items-center justify-center text-primary border border-primary/20 shadow-[0_0_30px_-10px_rgba(254,137,31,0.3)]">
+          <CheckCircle2 size={42} strokeWidth={3} />
+        </div>
+        <div className="space-y-3">
+          <h2 className="text-2xl font-bold text-white">Application Submitted!</h2>
+          <p className="text-text-secondary max-w-xs mx-auto text-sm leading-relaxed">
+            The bounty creator will review your application. You'll be notified once accepted.
+          </p>
+        </div>
+        <div className="flex flex-col gap-3 w-full max-w-xs pt-6">
+          <Button
+            variant="outline"
+            fullWidth
+            onClick={() => navigate('/tasks')}
+            className="border-white/10 text-white hover:bg-white/5 hover:text-white hover:border-white/20"
+          >
+            View My Tasks
+          </Button>
+          <Button fullWidth onClick={() => navigate('/explorer')}>Explore More</Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (applying) {
+    return (
+      <div className="space-y-6 animate-in slide-in-from-bottom-4 p-5 pb-32">
+        <div className="flex items-center gap-4">
+          <button onClick={() => setApplying(false)} className="p-2 -ml-2 hover:bg-surface rounded-full">
+            <ArrowLeft size={20} />
+          </button>
+          <h2 className="text-xl font-bold">Apply for Bounty</h2>
+        </div>
+
+        <div className="p-5 bg-surface border border-primary/30 rounded-xl shadow-[0_0_30px_-10px_rgba(254,137,31,0.1)]">
+          <div className="text-xs text-text-secondary mb-1 font-bold tracking-wider">APPLYING FOR</div>
+          <div className="font-semibold text-white text-lg">{bounty.title}</div>
+          <div className="text-primary font-bold mt-2 text-xl">${bounty.amount.toLocaleString()} USDC</div>
+        </div>
+
+        <form className="space-y-5" onSubmit={(e) => { e.preventDefault(); setSubmitted(true); }}>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-text-secondary">Cover Letter</label>
+            <textarea
+              className="w-full bg-surface border border-border rounded-xl p-4 h-40 text-sm focus:border-primary focus:outline-none resize-none placeholder:text-white/20"
+              placeholder="Explain why you're the best fit for this task..."
+              defaultValue="I have extensive experience with this specific issue. I've contributed to similar repositories before and understand the reconciliation logic required."
+            ></textarea>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-text-secondary">Estimated Completion</label>
+            <div className="relative">
+              <select className="w-full bg-surface border border-border rounded-xl p-4 text-sm focus:border-primary focus:outline-none appearance-none">
+                <option>Less than 3 days</option>
+                <option>3-7 Days</option>
+                <option>1-2 Weeks</option>
+              </select>
+              <div className="absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none text-text-secondary">▼</div>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-text-secondary">Relevant Links</label>
+            <input type="text" placeholder="github.com/your-username" className="w-full bg-surface border border-border rounded-xl p-4 text-sm focus:border-primary focus:outline-none placeholder:text-white/20" />
+          </div>
+
+          <div className="pt-6 fixed bottom-0 left-0 right-0 p-5 bg-background border-t border-border z-20">
+            <Button fullWidth size="lg">Submit Application</Button>
+          </div>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-full">
+      {/* Sticky Navbar Actions */}
+      <div className="flex items-center justify-between sticky top-0 bg-background/80 backdrop-blur-xl z-30 px-4 py-3 border-b border-white/5">
+        <button onClick={() => navigate(-1)} className="p-2 -ml-2 hover:bg-surface rounded-full transition-colors">
+          <ArrowLeft size={24} />
+        </button>
+        <div className="flex gap-2">
+          <button className="p-2 hover:bg-surface rounded-full text-text-secondary"><Share2 size={20} /></button>
+        </div>
+      </div>
+
+      <div className={`p-5 space-y-6 ${hideApply ? 'pb-10' : 'pb-32'}`}>
+        {/* Header Info */}
+        <div className="space-y-4">
+          <div className="flex items-center gap-1.5 text-primary bg-primary/10 w-fit px-2.5 py-0.5 rounded-full text-xs font-medium border border-primary/20">
+            <Github size={13} />
+            {bounty.repoOwner}/{bounty.repoName}
+          </div>
+
+          <h1 className="text-xl font-bold leading-tight">{bounty.title}</h1>
+
+          <div className="flex items-center justify-between p-4 bg-surface border border-border rounded-xl">
+            <div className="space-y-1">
+              <div className="text-[10px] text-text-secondary uppercase tracking-wider font-bold">Bounty Amount</div>
+              <div className="text-xl font-bold text-primary">${bounty.amount.toLocaleString()}</div>
+            </div>
+            <div className="text-right space-y-1">
+              <div className="text-[10px] text-text-secondary uppercase tracking-wider font-bold">Difficulty</div>
+              <Badge variant={bounty.difficulty === 'Advanced' ? 'error' : 'warning'}>{bounty.difficulty}</Badge>
+            </div>
+          </div>
+        </div>
+
+        {/* Tags */}
+        <div className="flex flex-wrap gap-2">
+          {bounty.tags.map(tag => (
+            <span key={tag} className="px-3 py-1.5 bg-surface rounded-full text-xs font-medium text-text-secondary border border-border">
+              {tag}
+            </span>
+          ))}
+        </div>
+
+        {/* Meta Row: Creator, Applications, Assignee */}
+        <div className="space-y-3">
+          {/* Creator */}
+          <div className="flex items-center gap-3 p-3 rounded-xl bg-surface/50 border border-border/50">
+            <img src={bounty.creator.avatarUrl} alt={bounty.creator.username} className="w-10 h-10 rounded-full" />
+            <div className="flex-1">
+              <div className="font-medium text-sm">@{bounty.creator.username}</div>
+              <div className="text-xs text-text-secondary">Bounty Creator • {bounty.creator.rating} ★</div>
+            </div>
+          </div>
+
+          {/* Application Count */}
+          {bounty.applicationCount !== undefined && (
+            <div className="flex items-center gap-3 p-3 rounded-xl bg-surface/50 border border-border/50">
+              <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center text-primary shrink-0">
+                <Users size={18} />
+              </div>
+              <div>
+                <div className="font-medium text-sm">
+                  {bounty.applicationCount === 0
+                    ? 'No applications yet'
+                    : `${bounty.applicationCount} application${bounty.applicationCount !== 1 ? 's' : ''}`}
+                </div>
+                <div className="text-xs text-text-secondary">Be the first to apply!</div>
+              </div>
+            </div>
+          )}
+
+          {/* Assignee */}
+          {bounty.assignee ? (
+            <div className="flex items-center gap-3 p-3 rounded-xl bg-surface/50 border border-border/50">
+              <img
+                src={bounty.assignee.avatarUrl}
+                alt={bounty.assignee.username}
+                className="w-10 h-10 rounded-full"
+              />
+              <div className="flex-1">
+                <div className="font-medium text-sm">@{bounty.assignee.username}</div>
+                <div className="text-xs text-text-secondary">Assigned Developer</div>
+              </div>
+              <Badge variant="warning">Assigned</Badge>
+            </div>
+          ) : bounty.status === 'Open' ? (
+            <div className="flex items-center gap-3 p-3 rounded-xl bg-surface/50 border border-border/50">
+              <div className="w-10 h-10 rounded-full bg-surface flex items-center justify-center text-text-secondary shrink-0">
+                <UserIcon size={18} />
+              </div>
+              <div>
+                <div className="font-medium text-sm text-text-secondary">Unassigned</div>
+                <div className="text-xs text-text-secondary">Open for applications</div>
+              </div>
+              <Badge variant="success">Open</Badge>
+            </div>
+          ) : null}
+        </div>
+
+        {/* Tabs / Sections */}
+        <div className="space-y-5">
+          <div className="space-y-3">
+            <h3 className="text-lg font-semibold border-l-4 border-primary pl-3">Description</h3>
+            <div className="text-text-secondary leading-relaxed text-sm space-y-4">
+              <p>{bounty.description}</p>
+              <p>Here is some additional context usually provided in the markdown. The developer must ensure that the fix passes all regression tests.</p>
+
+              <div className="bg-[#111] p-4 rounded-lg font-mono text-xs border border-white/10 overflow-x-auto text-gray-300">
+                <span className="text-purple-400">const</span> <span className="text-blue-400">bug</span> = <span className="text-yellow-400">await</span> reproduce(<span className="text-orange-400">true</span>);
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-3 pt-2">
+            <h3 className="text-lg font-semibold border-l-4 border-primary pl-3">Requirements</h3>
+            <ul className="space-y-3">
+              {bounty.requirements.map((req, i) => (
+                <li key={i} className="flex gap-3 text-sm text-text-secondary bg-surface/30 p-3 rounded-lg border border-white/5">
+                  <Shield size={18} className="text-primary shrink-0 mt-0.5" />
+                  <span>{req}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="flex gap-2 items-center text-xs text-text-secondary pt-4 justify-center opacity-70">
+            <Calendar size={14} />
+            <span>Deadline: {new Date(bounty.deadline).toLocaleDateString()}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Sticky Bottom CTA */}
+      {!hideApply && bounty.status === 'Open' && !bounty.assignee && (
+        <div className="fixed bottom-0 left-0 right-0 p-4 pb-8 bg-background/80 backdrop-blur-xl border-t border-border z-20">
+          <Button
+            variant="primary"
+            fullWidth
+            size="lg"
+            onClick={() => setApplying(true)}
+            className="shadow-xl shadow-primary/20"
+          >
+            Apply for Bounty
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/mobile/types.ts
+++ b/packages/mobile/types.ts
@@ -1,0 +1,68 @@
+export type Difficulty = 'Beginner' | 'Intermediate' | 'Advanced';
+export type Status = 'Open' | 'Assigned' | 'In Review' | 'Completed' | 'Cancelled';
+export type ApplicationStatus = 'Pending' | 'Accepted' | 'Rejected';
+export type SubmissionStatus = 'Pending' | 'Approved' | 'Rejected' | 'Disputed';
+
+export interface User {
+  id: string;
+  username: string;
+  avatarUrl: string;
+  totalEarned: number;
+  bountiesCompleted: number;
+  successRate: number;
+  techStack: string[];
+  walletAddress: string;
+}
+
+export interface Bounty {
+  id: string;
+  repoOwner: string;
+  repoName: string;
+  title: string;
+  description: string;
+  amount: number;
+  tags: string[];
+  difficulty: Difficulty;
+  deadline: string; // ISO date string
+  status: Status;
+  creator: {
+    username: string;
+    avatarUrl: string;
+    rating: number;
+  };
+  requirements: string[];
+  /** Number of applications submitted for this bounty */
+  applicationCount?: number;
+  /** Developer assigned to work on this bounty, if any */
+  assignee?: {
+    username: string;
+    avatarUrl: string;
+  } | null;
+}
+
+export interface Application {
+  id: string;
+  bountyId: string;
+  status: ApplicationStatus;
+  appliedAt: string;
+}
+
+export interface Transaction {
+  id: string;
+  type: 'Earning' | 'Withdrawal';
+  amount: number;
+  date: string;
+  status: 'Completed' | 'Pending' | 'Failed';
+  description: string;
+}
+
+export interface Task {
+  id: string;
+  title: string;
+  amount: number;
+  status: string;
+  repo: string;
+  deadline?: string;
+  submittedAt?: string;
+  completedAt?: string;
+}


### PR DESCRIPTION
## Summary

Closes #21

Implements the `GET /api/bounties/:id` endpoint to return full bounty details including creator info, application count, assignee info, and current status.

---

## Changes

### Backend — `packages/api/src/index.ts`
- Added `GET /api/bounties/:id` route to the Hono server
- Proxies to the main DevAsign API (configurable via `DEVASIGN_API_URL` env var, defaults to `https://api.devasign.com`)
- Forwards `Authorization` header for authenticated requests
- Returns `404` when the bounty is not found
- Returns `502` on upstream API failure with a descriptive error message
- Validates input: rejects blank/missing IDs with `400`

### Types — `packages/mobile/types.ts`
- Added `applicationCount?: number` to `Bounty` interface
- Added `assignee?: { username: string; avatarUrl: string } | null` to represent the assigned developer

### Frontend — `packages/mobile/pages/BountyDetail.tsx`
- Replaced `MOCK_BOUNTIES.find()` with a real `fetch()` call to `/api/bounties/:id`
- Added loading state (animated placeholder) and error state
- `AbortController` cleanup on component unmount
- Displays **applicationCount** with proper pluralisation (`3 applications`)
- Displays an **assignee card** (avatar + username) when the bounty is assigned
- Displays an "Unassigned / Open for applications" card when status is `Open` and no assignee exists
- The **Apply for Bounty** CTA is now only shown for `Open`, unassigned bounties

---

## Environment Variable

| Variable | Description | Default |
|---|---|---|
| `DEVASIGN_API_URL` | Base URL for upstream DevAsign API | `https://api.devasign.com` |

---

## Testing

```bash
# Start the API
cd packages/api && npm run dev

# In another terminal, test the new endpoint
curl http://localhost:3001/api/bounties/<id>          # 200 OK
curl http://localhost:3001/api/bounties/nonexistent   # 404
curl http://localhost:3001/api/bounties/              # 404 (missing id)
```