### PR TITLE
feat: implement GET /submissions/mine and GET /submissions/:id endpoints (#27, #28)

### DIFF
--- a/packages/api/src/__tests__/submissions.test.ts
+++ b/packages/api/src/__tests__/submissions.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { createApp } from '../app';
+import { verify } from 'hono/jwt';
+
+// Mock hono/jwt verify
+vi.mock('hono/jwt', () => ({
+    verify: vi.fn(),
+}));
+
+// Mock the database
+vi.mock('../db', () => ({
+    db: {
+        select: vi.fn().mockReturnThis(),
+        from: vi.fn().mockReturnThis(),
+        innerJoin: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        orderBy: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        offset: vi.fn().mockReturnThis(),
+        query: {
+            submissions: {
+                findFirst: vi.fn(),
+            },
+            bounties: {
+                findFirst: vi.fn(),
+            },
+            disputes: {
+                findMany: vi.fn(),
+            },
+        },
+    },
+}));
+
+import { db } from '../db';
+
+describe('GET /api/submissions/mine', () => {
+    let app: ReturnType<typeof createApp>;
+
+    beforeAll(() => {
+        app = createApp();
+        vi.mocked(verify).mockResolvedValue({
+            sub: 'user-123',
+            username: 'testuser',
+            exp: Math.floor(Date.now() / 1000) + 3600,
+        });
+        process.env.JWT_PUBLIC_KEY = '-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----';
+    });
+
+    it('should return paginated list of user submissions', async () => {
+        const mockSubmissions = [
+            {
+                id: 'sub-1',
+                bountyId: 'bounty-1',
+                bountyTitle: 'Fix login bug',
+                status: 'pending',
+                prUrl: 'https://github.com/org/repo/pull/1',
+                createdAt: new Date('2026-03-01'),
+                updatedAt: new Date('2026-03-01'),
+            },
+            {
+                id: 'sub-2',
+                bountyId: 'bounty-2',
+                bountyTitle: 'Add dark mode',
+                status: 'approved',
+                prUrl: 'https://github.com/org/repo/pull/2',
+                createdAt: new Date('2026-02-28'),
+                updatedAt: new Date('2026-03-02'),
+            },
+        ];
+
+        // Chain: select -> from -> innerJoin -> where -> orderBy -> limit -> offset -> returns mockSubmissions
+        vi.mocked(db.select).mockReturnValue(db as any);
+        vi.mocked(db.from).mockReturnValue(db as any);
+        vi.mocked(db.innerJoin).mockReturnValue(db as any);
+        vi.mocked(db.where).mockReturnValue(db as any);
+        vi.mocked(db.orderBy).mockReturnValue(db as any);
+        vi.mocked(db.limit).mockReturnValue(db as any);
+        vi.mocked(db.offset).mockResolvedValue(mockSubmissions);
+
+        const res = await app.request('/api/submissions/mine', {
+            headers: { Authorization: 'Bearer valid.token' },
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.data).toHaveLength(2);
+        expect(body.data[0].id).toBe('sub-1');
+        expect(body.data[0].bountyTitle).toBe('Fix login bug');
+        expect(body.data[1].status).toBe('approved');
+        expect(body.meta.has_more).toBe(false);
+    });
+
+    it('should return 401 without auth', async () => {
+        const res = await app.request('/api/submissions/mine');
+        expect(res.status).toBe(401);
+    });
+});
+
+describe('GET /api/submissions/:id', () => {
+    let app: ReturnType<typeof createApp>;
+
+    beforeAll(() => {
+        app = createApp();
+        vi.mocked(verify).mockResolvedValue({
+            sub: 'user-123',
+            username: 'testuser',
+            exp: Math.floor(Date.now() / 1000) + 3600,
+        });
+        process.env.JWT_PUBLIC_KEY = '-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----';
+    });
+
+    it('should return full submission details with disputes', async () => {
+        const mockSubmission = {
+            id: 'sub-1',
+            bountyId: 'bounty-1',
+            developerId: 'user-123',
+            prUrl: 'https://github.com/org/repo/pull/1',
+            supportingLinks: ['https://example.com/test'],
+            notes: 'Fixed the issue',
+            status: 'rejected',
+            rejectionReason: 'Tests are missing',
+            createdAt: new Date('2026-03-01'),
+            updatedAt: new Date('2026-03-02'),
+        };
+
+        const mockBounty = {
+            id: 'bounty-1',
+            title: 'Fix login bug',
+        };
+
+        const mockDisputes = [
+            {
+                id: 'disp-1',
+                reason: 'Tests were included in a separate commit',
+                evidenceLinks: ['https://github.com/org/repo/commit/abc123'],
+                status: 'open',
+                createdAt: new Date('2026-03-03'),
+                updatedAt: new Date('2026-03-03'),
+            },
+        ];
+
+        vi.mocked(db.query.submissions.findFirst).mockResolvedValue(mockSubmission as any);
+        vi.mocked(db.query.bounties.findFirst).mockResolvedValue(mockBounty as any);
+        vi.mocked(db.query.disputes.findMany).mockResolvedValue(mockDisputes as any);
+
+        const res = await app.request('/api/submissions/sub-1', {
+            headers: { Authorization: 'Bearer valid.token' },
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.id).toBe('sub-1');
+        expect(body.bountyTitle).toBe('Fix login bug');
+        expect(body.status).toBe('rejected');
+        expect(body.rejectionReason).toBe('Tests are missing');
+        expect(body.disputes).toHaveLength(1);
+        expect(body.disputes[0].reason).toBe('Tests were included in a separate commit');
+    });
+
+    it('should return 404 if submission not found', async () => {
+        vi.mocked(db.query.submissions.findFirst).mockResolvedValue(undefined);
+
+        const res = await app.request('/api/submissions/nonexistent', {
+            headers: { Authorization: 'Bearer valid.token' },
+        });
+
+        expect(res.status).toBe(404);
+        const body = await res.json();
+        expect(body.error).toBe('Submission not found');
+    });
+
+    it('should return 403 if user does not own the submission', async () => {
+        vi.mocked(db.query.submissions.findFirst).mockResolvedValue({
+            id: 'sub-1',
+            developerId: 'other-user',
+            bountyId: 'bounty-1',
+        } as any);
+
+        const res = await app.request('/api/submissions/sub-1', {
+            headers: { Authorization: 'Bearer valid.token' },
+        });
+
+        expect(res.status).toBe(403);
+        const body = await res.json();
+        expect(body.error).toBe('Forbidden');
+    });
+
+    it('should return 401 without auth', async () => {
+        const res = await app.request('/api/submissions/sub-1');
+        expect(res.status).toBe(401);
+    });
+});

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -4,6 +4,7 @@ import { logger } from 'hono/logger';
 import auth from './routes/auth';
 import bounties from './routes/bounties';
 import tasks from './routes/tasks';
+import submissions from './routes/submissions';
 import { authMiddleware, Variables } from './middleware/auth';
 
 /**
@@ -45,6 +46,7 @@ export function createApp() {
     app.use('/api/*', authMiddleware);
     app.route('/api/bounties', bounties);
     app.route('/api/tasks', tasks);
+    app.route('/api/submissions', submissions);
 
     app.post('/api/gemini', async (c) => {
         const user = c.get('user');

--- a/packages/api/src/routes/submissions.ts
+++ b/packages/api/src/routes/submissions.ts
@@ -1,0 +1,115 @@
+import { Hono } from 'hono';
+import { Variables } from '../middleware/auth';
+import { db } from '../db';
+import { submissions, bounties, disputes } from '../db/schema';
+import { eq, desc, and } from 'drizzle-orm';
+
+const submissionsRouter = new Hono<{ Variables: Variables }>();
+
+/**
+ * GET /api/submissions/mine
+ * Paginated list of the authenticated user's submissions.
+ * Returns bounty title, status, and creation date.
+ */
+submissionsRouter.get('/mine', async (c) => {
+    const user = c.get('user');
+    if (!user) {
+        return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    const query = c.req.query();
+    const limit = Math.min(parseInt(query.limit || '10'), 100);
+    const offset = Math.max(parseInt(query.offset || '0'), 0);
+
+    const results = await db
+        .select({
+            id: submissions.id,
+            bountyId: submissions.bountyId,
+            bountyTitle: bounties.title,
+            status: submissions.status,
+            prUrl: submissions.prUrl,
+            createdAt: submissions.createdAt,
+            updatedAt: submissions.updatedAt,
+        })
+        .from(submissions)
+        .innerJoin(bounties, eq(submissions.bountyId, bounties.id))
+        .where(eq(submissions.developerId, user.sub))
+        .orderBy(desc(submissions.createdAt))
+        .limit(limit + 1)
+        .offset(offset);
+
+    const hasMore = results.length > limit;
+    const data = hasMore ? results.slice(0, limit) : results;
+
+    return c.json({
+        data,
+        meta: {
+            limit,
+            offset,
+            has_more: hasMore,
+            count: data.length,
+        },
+    });
+});
+
+/**
+ * GET /api/submissions/:id
+ * Full submission details including review status, rejection reason, and associated dispute info.
+ */
+submissionsRouter.get('/:id', async (c) => {
+    const user = c.get('user');
+    if (!user) {
+        return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    const id = c.req.param('id');
+
+    // Fetch the submission
+    const submission = await db.query.submissions.findFirst({
+        where: eq(submissions.id, id),
+    });
+
+    if (!submission) {
+        return c.json({ error: 'Submission not found' }, 404);
+    }
+
+    // Only the developer who created the submission can view its full details
+    if (submission.developerId !== user.sub) {
+        return c.json({ error: 'Forbidden' }, 403);
+    }
+
+    // Fetch associated bounty info
+    const bounty = await db.query.bounties.findFirst({
+        where: eq(bounties.id, submission.bountyId),
+    });
+
+    // Fetch associated disputes
+    const relatedDisputes = await db.query.disputes.findMany({
+        where: eq(disputes.submissionId, id),
+        orderBy: [desc(disputes.createdAt)],
+    });
+
+    return c.json({
+        id: submission.id,
+        bountyId: submission.bountyId,
+        bountyTitle: bounty?.title ?? null,
+        developerId: submission.developerId,
+        prUrl: submission.prUrl,
+        supportingLinks: submission.supportingLinks,
+        notes: submission.notes,
+        status: submission.status,
+        rejectionReason: submission.rejectionReason,
+        createdAt: submission.createdAt,
+        updatedAt: submission.updatedAt,
+        disputes: relatedDisputes.map(d => ({
+            id: d.id,
+            reason: d.reason,
+            evidenceLinks: d.evidenceLinks,
+            status: d.status,
+            createdAt: d.createdAt,
+            updatedAt: d.updatedAt,
+        })),
+    });
+});
+
+export default submissionsRouter;


### PR DESCRIPTION
## Summary

Implements two new authenticated API endpoints for the submissions system:

### GET /api/submissions/mine
- Returns paginated list of authenticated user's submissions
- Includes bounty title, status, PR URL, and creation date
- Supports `limit` and `offset` query parameters (default: limit=10, max=100)

### GET /api/submissions/:id
- Returns full submission details including review status
- Includes rejection reason (if any) and associated dispute info
- Enforces ownership: only the submission creator can view details
- Returns 403 if user doesn't own the submission

## Implementation Details

- **Route module**: `packages/api/src/routes/submissions.ts` — clean Hono router following existing patterns
- **Tests**: `packages/api/src/__tests__/submissions.test.ts` — comprehensive tests covering happy path, pagination, auth, 403/404 cases
- **Registration**: Updated `packages/api/src/app.ts` to mount submissions router at `/api/submissions`

## Testing

Run with: `cd packages/api && npm test`

## Closes
- Closes #27
- Closes #28

## Payment
Solana Wallet: `CZkLs4m55JBffoowGUtyfqb5GrymUVxgr9kMTrXKfbJV`