### PR TITLE
feat: include relevanceScore in GET /bounties/recommended response

### DIFF
--- a/packages/api/src/__tests__/bounties_recommended.test.ts
+++ b/packages/api/src/__tests__/bounties_recommended.test.ts
@@ -80,8 +80,11 @@ describe('GET /api/bounties/recommended', () => {
         // Check sorting: Bounty 2 (2 score), Bounty 3 (1 score), Bounty 1 (0 score)
         expect(body.data).toHaveLength(3);
         expect(body.data[0].id).toBe('2');
+        expect(body.data[0].relevanceScore).toBe(2);
         expect(body.data[1].id).toBe('3');
+        expect(body.data[1].relevanceScore).toBe(1);
         expect(body.data[2].id).toBe('1');
+        expect(body.data[2].relevanceScore).toBe(0);
     });
 
     it('should fall back to sorting by createdAt for identical relevance scores', async () => {
@@ -117,7 +120,9 @@ describe('GET /api/bounties/recommended', () => {
         // Check sorting: Both have 1 score, so the newer one comes first
         expect(body.data).toHaveLength(2);
         expect(body.data[0].id).toBe('new');
+        expect(body.data[0].relevanceScore).toBe(1);
         expect(body.data[1].id).toBe('old');
+        expect(body.data[1].relevanceScore).toBe(1);
     });
 
     it('should use cache on subsequent requests within TTL', async () => {

--- a/packages/api/src/routes/bounties.ts
+++ b/packages/api/src/routes/bounties.ts
@@ -168,9 +168,12 @@ bountiesRouter.get('/recommended', async (c) => {
 
     let results = [];
 
-    // If no tech stack, just return latest open bounties
+    // If no tech stack, just return latest open bounties with relevanceScore: 0
     if (techStack.length === 0) {
-        results = openBounties.slice(0, 10);
+        results = openBounties.slice(0, 10).map(bounty => ({
+            ...bounty,
+            relevanceScore: 0,
+        }));
     } else {
         // Calculate relevance score
         const scoredBounties = openBounties.map(bounty => {
@@ -195,7 +198,7 @@ bountiesRouter.get('/recommended', async (c) => {
             return b.createdAt.getTime() - a.createdAt.getTime();
         });
 
-        results = scoredBounties.slice(0, 10).map(({ relevanceScore, ...rest }) => rest);
+        results = scoredBounties.slice(0, 10);
     }
 
     // Save to cache


### PR DESCRIPTION
## Fixes #22

The `GET /bounties/recommended` endpoint already implements weighted scoring against tech tags and caches results for 15 minutes, but it was **stripping the `relevanceScore`** from the response before returning it.

### Changes
- **Keep `relevanceScore` in response**: Removed the destructuring that stripped it (line 198)
- **Include `relevanceScore: 0`** for the no-tech-stack fallback path
- **Updated tests** to assert `relevanceScore` is present in the response

### Before
```json
{ "data": [{ "id": "2", "title": "Bounty 2", ... }] }
```

### After
```json
{ "data": [{ "id": "2", "title": "Bounty 2", "relevanceScore": 2, ... }] }
```

This allows clients to display the relevance score to users and understand why certain bounties were recommended.

@algora-io