### PR TITLE
feat: implement POST /submissions/:id/dispute endpoint

### DIFF
--- a/packages/api/src/__tests__/submissions.test.ts
+++ b/packages/api/src/__tests__/submissions.test.ts
@@ -111,6 +111,213 @@ describe('GET /api/submissions/mine', () => {
     });
 });
 
+describe('POST /api/submissions/:id/dispute', () => {
+    let app: ReturnType<typeof createApp>;
+
+    beforeAll(() => {
+        app = createApp();
+        process.env.JWT_PUBLIC_KEY = '-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----';
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(verify).mockResolvedValue({
+            sub: 'test-user-id',
+            id: 'test-user-id',
+            username: 'testuser',
+            exp: Math.floor(Date.now() / 1000) + 3600,
+        });
+    });
+
+    it('should return 401 if unauthorized', async () => {
+        vi.mocked(verify).mockRejectedValue(new Error('Invalid token'));
+
+        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/dispute', {
+            method: 'POST',
+            headers: {
+                Authorization: 'Bearer invalid.token',
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ reason: 'This is not fair' }),
+        });
+
+        expect(res.status).toBe(401);
+    });
+
+    it('should return 400 for invalid UUID', async () => {
+        const res = await app.request('/api/submissions/not-a-uuid/dispute', {
+            method: 'POST',
+            headers: {
+                Authorization: 'Bearer valid.token',
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ reason: 'This is not fair' }),
+        });
+
+        expect(res.status).toBe(400);
+    });
+
+    it('should return 400 if reason is missing', async () => {
+        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/dispute', {
+            method: 'POST',
+            headers: {
+                Authorization: 'Bearer valid.token',
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({}),
+        });
+
+        expect(res.status).toBe(400);
+    });
+
+    it('should return 404 if submission not found', async () => {
+        const mockWhere = vi.fn().mockResolvedValue([]);
+        const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+        vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
+
+        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/dispute', {
+            method: 'POST',
+            headers: {
+                Authorization: 'Bearer valid.token',
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ reason: 'This is not fair' }),
+        });
+
+        expect(res.status).toBe(404);
+        const body = await res.json();
+        expect(body.error).toBe('Submission not found');
+    });
+
+    it('should return 400 if submission is not rejected', async () => {
+        const mockSubmission = {
+            id: '123e4567-e89b-12d3-a456-426614174000',
+            status: 'pending',
+            developerId: 'test-user-id',
+        };
+
+        const mockWhere = vi.fn().mockResolvedValue([mockSubmission]);
+        const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+        vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
+
+        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/dispute', {
+            method: 'POST',
+            headers: {
+                Authorization: 'Bearer valid.token',
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ reason: 'This is not fair' }),
+        });
+
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error).toBe('Only rejected submissions can be disputed');
+    });
+
+    it('should return 409 if dispute already exists', async () => {
+        const mockSubmission = {
+            id: '123e4567-e89b-12d3-a456-426614174000',
+            status: 'rejected',
+            developerId: 'test-user-id',
+        };
+        const mockExistingDispute = { id: 'd-1', submissionId: '123e4567-e89b-12d3-a456-426614174000' };
+
+        const mockWhere2 = vi.fn().mockResolvedValue([mockExistingDispute]);
+        const mockFrom2 = vi.fn().mockReturnValue({ where: mockWhere2 });
+
+        const mockWhere1 = vi.fn().mockResolvedValue([mockSubmission]);
+        const mockFrom1 = vi.fn().mockReturnValue({ where: mockWhere1 });
+
+        let callCount = 0;
+        vi.mocked(db.select).mockImplementation(() => {
+            callCount++;
+            if (callCount === 1) return { from: mockFrom1 } as any;
+            return { from: mockFrom2 } as any;
+        });
+
+        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/dispute', {
+            method: 'POST',
+            headers: {
+                Authorization: 'Bearer valid.token',
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ reason: 'This is not fair' }),
+        });
+
+        expect(res.status).toBe(409);
+        const body = await res.json();
+        expect(body.error).toBe('A dispute already exists for this submission');
+    });
+
+    it('should create a dispute and return 201', async () => {
+        const mockSubmission = {
+            id: '123e4567-e89b-12d3-a456-426614174000',
+            status: 'rejected',
+            developerId: 'test-user-id',
+        };
+
+        const mockNewDispute = {
+            id: 'new-dispute-id',
+            submissionId: '123e4567-e89b-12d3-a456-426614174000',
+            reason: 'The code compiles fine on CI',
+            evidenceLinks: ['https://github.com/example/runs/123'],
+            status: 'open',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        };
+
+        // Mock for submission lookup
+        const mockWhere1 = vi.fn().mockResolvedValue([mockSubmission]);
+        const mockFrom1 = vi.fn().mockReturnValue({ where: mockWhere1 });
+
+        // Mock for existing dispute check (returns empty - no existing dispute)
+        const mockWhere2 = vi.fn().mockResolvedValue([]);
+        const mockFrom2 = vi.fn().mockReturnValue({ where: mockWhere2 });
+
+        // Mock for transaction
+        const mockReturning = vi.fn().mockResolvedValue([mockNewDispute]);
+        const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
+        const mockInsert = vi.fn().mockReturnValue({ values: mockValues });
+
+        const mockSet = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(null) });
+        const mockUpdate = vi.fn().mockReturnValue({ set: mockSet });
+
+        const mockTransaction = vi.fn().mockImplementation(async (callback: any) => {
+            return callback({
+                insert: mockInsert,
+                update: mockUpdate,
+            });
+        });
+
+        let selectCallCount = 0;
+        vi.mocked(db.select).mockImplementation(() => {
+            selectCallCount++;
+            if (selectCallCount === 1) return { from: mockFrom1 } as any;
+            return { from: mockFrom2 } as any;
+        });
+
+        (db as any).transaction = mockTransaction;
+
+        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/dispute', {
+            method: 'POST',
+            headers: {
+                Authorization: 'Bearer valid.token',
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                reason: 'The code compiles fine on CI',
+                evidence_links: ['https://github.com/example/runs/123'],
+            }),
+        });
+
+        expect(res.status).toBe(201);
+        const body = await res.json();
+        expect(body.data.id).toBe('new-dispute-id');
+        expect(body.data.status).toBe('open');
+        expect(body.data.reason).toBe('The code compiles fine on CI');
+    });
+});
+
 describe('GET /api/submissions/:id', () => {
     let app: ReturnType<typeof createApp>;
 

--- a/packages/api/src/routes/submissions.ts
+++ b/packages/api/src/routes/submissions.ts
@@ -110,4 +110,83 @@ submissionsRouter.get(
     }
 );
 
+/**
+ * POST /api/submissions/:id/dispute
+ * Allows a developer to dispute a rejected submission.
+ * Validates submission was rejected and belongs to the user.
+ * Creates a dispute record with 'open' status and transitions
+ * the submission status to 'disputed'.
+ */
+const disputeSchema = z.object({
+    reason: z.string().min(1, 'Dispute reason is required').max(2000),
+    evidence_links: z.array(z.string().url()).optional().default([]),
+});
+
+submissionsRouter.post(
+    '/:id/dispute',
+    zValidator('param', idSchema),
+    zValidator('json', disputeSchema),
+    async (c) => {
+        const user = c.get('user');
+        if (!user) {
+            return c.json({ error: 'Unauthorized' }, 401);
+        }
+
+        const { id } = c.req.valid('param');
+        const { reason, evidence_links } = c.req.valid('json');
+
+        // Fetch the submission and verify ownership + status
+        const [submission] = await db
+            .select()
+            .from(submissions)
+            .where(and(eq(submissions.id, id), eq(submissions.developerId, user.id)));
+
+        if (!submission) {
+            return c.json({ error: 'Submission not found' }, 404);
+        }
+
+        if (submission.status !== 'rejected') {
+            return c.json(
+                { error: 'Only rejected submissions can be disputed' },
+                400
+            );
+        }
+
+        // Check if a dispute already exists for this submission
+        const [existingDispute] = await db
+            .select()
+            .from(disputes)
+            .where(eq(disputes.submissionId, id));
+
+        if (existingDispute) {
+            return c.json(
+                { error: 'A dispute already exists for this submission' },
+                409
+            );
+        }
+
+        // Create the dispute and update submission status in a transaction
+        const [dispute] = await db.transaction(async (tx) => {
+            const [newDispute] = await tx
+                .insert(disputes)
+                .values({
+                    submissionId: id,
+                    reason,
+                    evidenceLinks: evidence_links,
+                    status: 'open',
+                })
+                .returning();
+
+            await tx
+                .update(submissions)
+                .set({ status: 'disputed' })
+                .where(eq(submissions.id, id));
+
+            return [newDispute];
+        });
+
+        return c.json({ data: dispute }, 201);
+    }
+);
+
 export default submissionsRouter;


### PR DESCRIPTION
## Summary

Implements `POST /api/submissions/:id/dispute` endpoint as described in #29.

## Changes

- **packages/api/src/routes/submissions.ts**: Added dispute endpoint with full validation
- **packages/api/src/__tests__/submissions.test.ts**: Added 7 new tests covering all paths

## Behavior

1. **Auth**: Requires valid JWT; returns 401 if unauthorized
2. **Validation**: 
   - Returns 400 for invalid UUID or missing `reason`
   - Returns 400 if submission status is not `rejected`
3. **Duplicate prevention**: Returns 409 if a dispute already exists for this submission
4. **Success**: Creates dispute with `open` status and transitions submission to `disputed` in a transaction, returns 201

## Request Body

```json
{
  "reason": "The code compiles fine on CI",
  "evidence_links": ["https://github.com/example/runs/123"]
}
```

Closes #29
