### PR TITLE
feat: implement POST /submissions/:id/dispute endpoint

### DIFF
--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -434,7 +434,6 @@
         "../../node_modules/.pnpm/hono@4.11.9/node_modules/hono": {
             "version": "4.11.9",
             "license": "MIT",
-            "peer": true,
             "devDependencies": {
                 "@hono/eslint-config": "^2.0.5",
                 "@hono/node-server": "^1.13.5",
@@ -757,7 +756,6 @@
         "../../node_modules/.pnpm/zod@4.3.6/node_modules/zod": {
             "version": "4.3.6",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/packages/api/src/__tests__/submissions.test.ts
+++ b/packages/api/src/__tests__/submissions.test.ts
@@ -263,7 +263,7 @@ describe('POST /api/submissions/:id/dispute', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
-nt POST /submissions/:id/dispute endpoint)
+        // Default auth bypass
         vi.mocked(verify).mockResolvedValue({
             sub: 'test-user-id',
             id: 'test-user-id',
@@ -279,23 +279,39 @@ nt POST /submissions/:id/dispute endpoint)
             method: 'POST',
             headers: {
                 Authorization: 'Bearer invalid.token',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ reason: 'Valid dispute' })
         });
 
         expect(res.status).toBe(401);
     });
 
-nt POST /submissions/:id/dispute endpoint)
+    it('should return 400 for invalid request body', async () => {
+        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/dispute', {
+            method: 'POST',
+            headers: {
+                Authorization: 'Bearer valid.token',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ evidenceLinks: ['not-a-url'] })
         });
 
         expect(res.status).toBe(400);
     });
 
+    it('should return 404 if submission is not found or not owned by user', async () => {
+        const mockWhere = vi.fn().mockResolvedValue([]);
+        const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
         vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
 
         const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/dispute', {
             method: 'POST',
             headers: {
                 Authorization: 'Bearer valid.token',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ reason: 'Valid reason' })
         });
 
         expect(res.status).toBe(404);
@@ -304,28 +320,337 @@ nt POST /submissions/:id/dispute endpoint)
     });
 
     it('should return 400 if submission is not rejected', async () => {
-nt POST /submissions/:id/dispute endpoint)
+        const mockWhere = vi.fn().mockResolvedValue([{ status: 'approved' }]);
+        const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
         vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
 
         const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/dispute', {
             method: 'POST',
             headers: {
                 Authorization: 'Bearer valid.token',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ reason: 'Valid reason' })
         });
 
         expect(res.status).toBe(400);
         const body = await res.json();
         expect(body.error).toBe('Only rejected submissions can be disputed');
-nt POST /submissions/:id/dispute endpoint)
+    });
+
+    it('should return 400 if a dispute already exists', async () => {
+        // First db.select() -> finding the submission
+        const mockSubmissionWhere = vi.fn().mockResolvedValue([{ id: 'sub-id', status: 'rejected' }]);
+        const mockSubmissionFrom = vi.fn().mockReturnValue({ where: mockSubmissionWhere });
+
+        // Second db.select() -> checking for existing disputes
+        const mockDisputeWhere = vi.fn().mockResolvedValue([{ id: 'existing-dispute' }]);
+        const mockDisputeFrom = vi.fn().mockReturnValue({ where: mockDisputeWhere });
+
+        vi.mocked(db.select)
+            .mockReturnValueOnce({ from: mockSubmissionFrom } as any)
+            .mockReturnValueOnce({ from: mockDisputeFrom } as any);
+
+        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/dispute', {
+            method: 'POST',
+            headers: {
+                Authorization: 'Bearer valid.token',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ reason: 'Valid reason' })
+        });
+
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error).toBe('A dispute already exists for this submission');
+    });
+
+    it('should successfully create a dispute and update status', async () => {
+        const mockSubmissionWhere = vi.fn().mockResolvedValue([{ id: 'sub-id', status: 'rejected' }]);
+        const mockSubmissionFrom = vi.fn().mockReturnValue({ where: mockSubmissionWhere });
+
+        const mockDisputeWhere = vi.fn().mockResolvedValue([]);
+        const mockDisputeFrom = vi.fn().mockReturnValue({ where: mockDisputeWhere });
+
+        vi.mocked(db.select)
+            .mockReturnValueOnce({ from: mockSubmissionFrom } as any)
+            .mockReturnValueOnce({ from: mockDisputeFrom } as any);
+
+        // Mock database transaction
+        const mockUpdateReturning = vi.fn().mockResolvedValue([{ id: 'sub-id' }]);
+        const mockUpdateWhere = vi.fn().mockReturnValue({ returning: mockUpdateReturning });
+        const mockUpdateSet = vi.fn().mockReturnValue({ where: mockUpdateWhere });
+        const mockUpdate = vi.fn().mockReturnValue({ set: mockUpdateSet });
+
+        const mockInsertReturning = vi.fn().mockResolvedValue([{ id: 'new-dispute-id', submissionId: 'sub-id', reason: 'Unfair rejection', status: 'open' }]);
+        const mockInsertValues = vi.fn().mockReturnValue({ returning: mockInsertReturning });
+        const mockInsert = vi.fn().mockReturnValue({ values: mockInsertValues });
+
+        // We temporarily mock db.transaction on the db object since db.transaction is untyped mocking usually
+        db.transaction = vi.fn().mockImplementation(async (cb) => {
+            return cb({
+                update: mockUpdate,
+                insert: mockInsert
+            });
         });
 
         const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/dispute', {
             method: 'POST',
             headers: {
                 Authorization: 'Bearer valid.token',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ reason: 'Unfair rejection', evidenceLinks: ['https://example.com'] })
+        });
+
+        expect(res.status).toBe(201);
+        const body = await res.json();
+        expect(body.data.id).toBe('new-dispute-id');
+        expect(body.data.reason).toBe('Unfair rejection');
+        expect(body.data.status).toBe('open');
+
+        // Restore original transaction just in case
+        vi.restoreAllMocks();
+    });
+
+    it('should return 409 if submission is modified concurrently', async () => {
+        const mockSubmissionWhere = vi.fn().mockResolvedValue([{ id: 'sub-id', status: 'rejected' }]);
+        const mockSubmissionFrom = vi.fn().mockReturnValue({ where: mockSubmissionWhere });
+
+        const mockDisputeWhere = vi.fn().mockResolvedValue([]);
+        const mockDisputeFrom = vi.fn().mockReturnValue({ where: mockDisputeWhere });
+
+        vi.mocked(db.select)
+            .mockReturnValueOnce({ from: mockSubmissionFrom } as any)
+            .mockReturnValueOnce({ from: mockDisputeFrom } as any);
+
+        // Mock database transaction to simulate concurrent modification (0 rows updated)
+        const mockUpdateReturning = vi.fn().mockResolvedValue([]);
+        const mockUpdateWhere = vi.fn().mockReturnValue({ returning: mockUpdateReturning });
+        const mockUpdateSet = vi.fn().mockReturnValue({ where: mockUpdateWhere });
+        const mockUpdate = vi.fn().mockReturnValue({ set: mockUpdateSet });
+
+        db.transaction = vi.fn().mockImplementation(async (cb) => {
+            return cb({
+                update: mockUpdate,
+                rollback: () => { throw new Error('Rollback'); }
+            });
+        });
+
+        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/dispute', {
+            method: 'POST',
+            headers: {
+                Authorization: 'Bearer valid.token',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ reason: 'Unfair rejection' })
         });
 
         expect(res.status).toBe(409);
         const body = await res.json();
+        expect(body.error).toBe('Failed to create dispute or submission was modified concurrently');
+    });
+});
+
+describe('POST /api/submissions/:id/approve', () => {
+    let app: ReturnType<typeof createApp>;
+
+    beforeAll(() => {
+        app = createApp();
+        process.env.JWT_PUBLIC_KEY = '-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----';
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(verify).mockResolvedValue({
+            sub: 'test-user-id',
+            id: 'test-user-id',
+            username: 'testuser',
+            exp: Math.floor(Date.now() / 1000) + 3600,
+        });
+    });
+
+    it('should return 401 if unauthorized', async () => {
+        vi.mocked(verify).mockRejectedValue(new Error('Invalid token'));
+
+        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/approve', {
+            method: 'POST',
+            headers: { Authorization: 'Bearer invalid.token' }
+        });
+
+        expect(res.status).toBe(401);
+    });
+
+    it('should return 404 if submission is not found', async () => {
+        const mockWhere = vi.fn().mockResolvedValue([]);
+        const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
+        const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+        vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
+
+        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/approve', {
+            method: 'POST',
+            headers: { Authorization: 'Bearer valid.token' }
+        });
+
+        expect(res.status).toBe(404);
+    });
+
+    it('should return 403 if user is not the bounty creator', async () => {
+        const mockWhere = vi.fn().mockResolvedValue([{ 
+            submission: { id: 's-1', status: 'pending' }, 
+            bounty: { id: 'b-1', creatorId: 'different-user' } 
+        }]);
+        const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
+        const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+        vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
+
+        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/approve', {
+            method: 'POST',
+            headers: { Authorization: 'Bearer valid.token' }
+        });
+
+        expect(res.status).toBe(403);
+    });
+    
+    it('should return 400 if submission is not pending or disputed', async () => {
+        const mockWhere = vi.fn().mockResolvedValue([{ 
+            submission: { id: 's-1', status: 'rejected' }, 
+            bounty: { id: 'b-1', creatorId: 'test-user-id' } 
+        }]);
+        const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
+        const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+        vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
+
+        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/approve', {
+            method: 'POST',
+            headers: { Authorization: 'Bearer valid.token' }
+        });
+
+        expect(res.status).toBe(400);
+    });
+
+    it('should successfully approve submission and trigger payment', async () => {
+        const mockWhere = vi.fn().mockResolvedValue([{ 
+            submission: { id: '123e4567-e89b-12d3-a456-426614174000', status: 'pending', developerId: 'dev-1' }, 
+            bounty: { id: 'b-1', creatorId: 'test-user-id', amountUsdc: '100.00' } 
+        }]);
+        const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
+        const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+        vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
+
+        const mockUpdateReturning = vi.fn().mockResolvedValue([{ id: '123e4567-e89b-12d3-a456-426614174000' }]);
+        const mockUpdateWhere = vi.fn().mockReturnValue({ returning: mockUpdateReturning });
+        const mockUpdateSet = vi.fn().mockReturnValue({ where: mockUpdateWhere });
+        const mockUpdate = vi.fn().mockReturnValue({ set: mockUpdateSet });
+
+        const mockInsertValues = vi.fn().mockResolvedValue([{ id: 'mock-tx-id' }]);
+        const mockInsert = vi.fn().mockReturnValue({ values: mockInsertValues });
+
+        db.transaction = vi.fn().mockImplementation(async (cb) => {
+            return cb({
+                update: mockUpdate,
+                insert: mockInsert
+            });
+        });
+
+        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/approve', {
+            method: 'POST',
+            headers: { Authorization: 'Bearer valid.token' }
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.message).toBe('Submission approved and payment triggered successfully');
+        
+        // Restore transaction
+        vi.restoreAllMocks();
+    });
+});
+
+describe('POST /api/submissions/:id/reject', () => {
+    let app: ReturnType<typeof createApp>;
+
+    beforeAll(() => {
+        app = createApp();
+        process.env.JWT_PUBLIC_KEY = '-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----';
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(verify).mockResolvedValue({
+            sub: 'test-user-id',
+            id: 'test-user-id',
+            username: 'testuser',
+            exp: Math.floor(Date.now() / 1000) + 3600,
+        });
+    });
+
+    it('should return 401 if unauthorized', async () => {
+        vi.mocked(verify).mockRejectedValue(new Error('Invalid token'));
+
+        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/reject', {
+            method: 'POST',
+            headers: { Authorization: 'Bearer invalid.token', 'Content-Type': 'application/json' },
+            body: JSON.stringify({ rejection_reason: 'reason' })
+        });
+
+        expect(res.status).toBe(401);
+    });
+
+    it('should return 400 for missing rejection reason', async () => {
+        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/reject', {
+            method: 'POST',
+            headers: { Authorization: 'Bearer valid.token', 'Content-Type': 'application/json' },
+            body: JSON.stringify({})
+        });
+
+        expect(res.status).toBe(400);
+    });
+
+    it('should return 403 if user is not the bounty creator', async () => {
+        const mockWhere = vi.fn().mockResolvedValue([{ 
+            submission: { id: 's-1', status: 'pending' }, 
+            bounty: { id: 'b-1', creatorId: 'different-user' } 
+        }]);
+        const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
+        const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+        vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
+
+        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/reject', {
+            method: 'POST',
+            headers: { Authorization: 'Bearer valid.token', 'Content-Type': 'application/json' },
+            body: JSON.stringify({ rejection_reason: 'reason' })
+        });
+
+        expect(res.status).toBe(403);
+    });
+
+    it('should successfully reject submission', async () => {
+        const mockWhere = vi.fn().mockResolvedValue([{ 
+            submission: { id: '123e4567-e89b-12d3-a456-426614174000', status: 'pending' }, 
+            bounty: { id: 'b-1', creatorId: 'test-user-id' } 
+        }]);
+        const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
+        const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+        vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
+
+        const mockUpdateReturning = vi.fn().mockResolvedValue([{ id: '123e4567-e89b-12d3-a456-426614174000' }]);
+        const mockUpdateWhere = vi.fn().mockReturnValue({ returning: mockUpdateReturning });
+        const mockUpdateSet = vi.fn().mockReturnValue({ where: mockUpdateWhere });
+        const mockUpdate = vi.fn().mockReturnValue({ set: mockUpdateSet });
+
+        db.transaction = vi.fn().mockImplementation(async (cb) => {
+            return cb({ update: mockUpdate });
+        });
+
+        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/reject', {
+            method: 'POST',
+            headers: { Authorization: 'Bearer valid.token', 'Content-Type': 'application/json' },
+            body: JSON.stringify({ rejection_reason: 'Does not meet requirements.' })
+        });
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.message).toBe('Submission rejected successfully');
     });
 });

--- a/packages/api/src/__tests__/submissions.test.ts
+++ b/packages/api/src/__tests__/submissions.test.ts
@@ -263,7 +263,7 @@ describe('POST /api/submissions/:id/dispute', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
-        // Default auth bypass
+nt POST /submissions/:id/dispute endpoint)
         vi.mocked(verify).mockResolvedValue({
             sub: 'test-user-id',
             id: 'test-user-id',
@@ -279,39 +279,26 @@ describe('POST /api/submissions/:id/dispute', () => {
             method: 'POST',
             headers: {
                 Authorization: 'Bearer invalid.token',
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ reason: 'Valid dispute' })
+nt POST /submissions/:id/dispute endpoint)
         });
 
         expect(res.status).toBe(401);
     });
 
-    it('should return 400 for invalid request body', async () => {
-        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/dispute', {
-            method: 'POST',
-            headers: {
-                Authorization: 'Bearer valid.token',
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ evidence_links: ['not-a-url'] })
+nt POST /submissions/:id/dispute endpoint)
         });
 
         expect(res.status).toBe(400);
     });
 
-    it('should return 404 if submission is not found or not owned by user', async () => {
-        const mockWhere = vi.fn().mockResolvedValue([]);
-        const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+nt POST /submissions/:id/dispute endpoint)
         vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
 
         const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/dispute', {
             method: 'POST',
             headers: {
                 Authorization: 'Bearer valid.token',
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ reason: 'Valid reason' })
+nt POST /submissions/:id/dispute endpoint)
         });
 
         expect(res.status).toBe(404);
@@ -320,337 +307,31 @@ describe('POST /api/submissions/:id/dispute', () => {
     });
 
     it('should return 400 if submission is not rejected', async () => {
-        const mockWhere = vi.fn().mockResolvedValue([{ status: 'approved' }]);
-        const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+nt POST /submissions/:id/dispute endpoint)
         vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
 
         const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/dispute', {
             method: 'POST',
             headers: {
                 Authorization: 'Bearer valid.token',
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ reason: 'Valid reason' })
+nt POST /submissions/:id/dispute endpoint)
         });
 
         expect(res.status).toBe(400);
         const body = await res.json();
         expect(body.error).toBe('Only rejected submissions can be disputed');
-    });
-
-    it('should return 400 if a dispute already exists', async () => {
-        // First db.select() -> finding the submission
-        const mockSubmissionWhere = vi.fn().mockResolvedValue([{ id: 'sub-id', status: 'rejected' }]);
-        const mockSubmissionFrom = vi.fn().mockReturnValue({ where: mockSubmissionWhere });
-
-        // Second db.select() -> checking for existing disputes
-        const mockDisputeWhere = vi.fn().mockResolvedValue([{ id: 'existing-dispute' }]);
-        const mockDisputeFrom = vi.fn().mockReturnValue({ where: mockDisputeWhere });
-
-        vi.mocked(db.select)
-            .mockReturnValueOnce({ from: mockSubmissionFrom } as any)
-            .mockReturnValueOnce({ from: mockDisputeFrom } as any);
-
-        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/dispute', {
-            method: 'POST',
-            headers: {
-                Authorization: 'Bearer valid.token',
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ reason: 'Valid reason' })
-        });
-
-        expect(res.status).toBe(400);
-        const body = await res.json();
-        expect(body.error).toBe('A dispute already exists for this submission');
-    });
-
-    it('should successfully create a dispute and update status', async () => {
-        const mockSubmissionWhere = vi.fn().mockResolvedValue([{ id: 'sub-id', status: 'rejected' }]);
-        const mockSubmissionFrom = vi.fn().mockReturnValue({ where: mockSubmissionWhere });
-
-        const mockDisputeWhere = vi.fn().mockResolvedValue([]);
-        const mockDisputeFrom = vi.fn().mockReturnValue({ where: mockDisputeWhere });
-
-        vi.mocked(db.select)
-            .mockReturnValueOnce({ from: mockSubmissionFrom } as any)
-            .mockReturnValueOnce({ from: mockDisputeFrom } as any);
-
-        // Mock database transaction
-        const mockUpdateReturning = vi.fn().mockResolvedValue([{ id: 'sub-id' }]);
-        const mockUpdateWhere = vi.fn().mockReturnValue({ returning: mockUpdateReturning });
-        const mockUpdateSet = vi.fn().mockReturnValue({ where: mockUpdateWhere });
-        const mockUpdate = vi.fn().mockReturnValue({ set: mockUpdateSet });
-
-        const mockInsertReturning = vi.fn().mockResolvedValue([{ id: 'new-dispute-id', submissionId: 'sub-id', reason: 'Unfair rejection', status: 'open' }]);
-        const mockInsertValues = vi.fn().mockReturnValue({ returning: mockInsertReturning });
-        const mockInsert = vi.fn().mockReturnValue({ values: mockInsertValues });
-
-        // We temporarily mock db.transaction on the db object since db.transaction is untyped mocking usually
-        db.transaction = vi.fn().mockImplementation(async (cb) => {
-            return cb({
-                update: mockUpdate,
-                insert: mockInsert
-            });
+nt POST /submissions/:id/dispute endpoint)
         });
 
         const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/dispute', {
             method: 'POST',
             headers: {
                 Authorization: 'Bearer valid.token',
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ reason: 'Unfair rejection', evidence_links: ['https://example.com'] })
-        });
-
-        expect(res.status).toBe(201);
-        const body = await res.json();
-        expect(body.data.id).toBe('new-dispute-id');
-        expect(body.data.reason).toBe('Unfair rejection');
-        expect(body.data.status).toBe('open');
-
-        // Restore original transaction just in case
-        vi.restoreAllMocks();
-    });
-
-    it('should return 409 if submission is modified concurrently', async () => {
-        const mockSubmissionWhere = vi.fn().mockResolvedValue([{ id: 'sub-id', status: 'rejected' }]);
-        const mockSubmissionFrom = vi.fn().mockReturnValue({ where: mockSubmissionWhere });
-
-        const mockDisputeWhere = vi.fn().mockResolvedValue([]);
-        const mockDisputeFrom = vi.fn().mockReturnValue({ where: mockDisputeWhere });
-
-        vi.mocked(db.select)
-            .mockReturnValueOnce({ from: mockSubmissionFrom } as any)
-            .mockReturnValueOnce({ from: mockDisputeFrom } as any);
-
-        // Mock database transaction to simulate concurrent modification (0 rows updated)
-        const mockUpdateReturning = vi.fn().mockResolvedValue([]);
-        const mockUpdateWhere = vi.fn().mockReturnValue({ returning: mockUpdateReturning });
-        const mockUpdateSet = vi.fn().mockReturnValue({ where: mockUpdateWhere });
-        const mockUpdate = vi.fn().mockReturnValue({ set: mockUpdateSet });
-
-        db.transaction = vi.fn().mockImplementation(async (cb) => {
-            return cb({
-                update: mockUpdate,
-                rollback: () => { throw new Error('Rollback'); }
-            });
-        });
-
-        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/dispute', {
-            method: 'POST',
-            headers: {
-                Authorization: 'Bearer valid.token',
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ reason: 'Unfair rejection' })
+nt POST /submissions/:id/dispute endpoint)
         });
 
         expect(res.status).toBe(409);
         const body = await res.json();
-        expect(body.error).toBe('Failed to create dispute or submission was modified concurrently');
-    });
-});
-
-describe('POST /api/submissions/:id/approve', () => {
-    let app: ReturnType<typeof createApp>;
-
-    beforeAll(() => {
-        app = createApp();
-        process.env.JWT_PUBLIC_KEY = '-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----';
-    });
-
-    beforeEach(() => {
-        vi.clearAllMocks();
-        vi.mocked(verify).mockResolvedValue({
-            sub: 'test-user-id',
-            id: 'test-user-id',
-            username: 'testuser',
-            exp: Math.floor(Date.now() / 1000) + 3600,
-        });
-    });
-
-    it('should return 401 if unauthorized', async () => {
-        vi.mocked(verify).mockRejectedValue(new Error('Invalid token'));
-
-        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/approve', {
-            method: 'POST',
-            headers: { Authorization: 'Bearer invalid.token' }
-        });
-
-        expect(res.status).toBe(401);
-    });
-
-    it('should return 404 if submission is not found', async () => {
-        const mockWhere = vi.fn().mockResolvedValue([]);
-        const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
-        const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
-        vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
-
-        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/approve', {
-            method: 'POST',
-            headers: { Authorization: 'Bearer valid.token' }
-        });
-
-        expect(res.status).toBe(404);
-    });
-
-    it('should return 403 if user is not the bounty creator', async () => {
-        const mockWhere = vi.fn().mockResolvedValue([{ 
-            submission: { id: 's-1', status: 'pending' }, 
-            bounty: { id: 'b-1', creatorId: 'different-user' } 
-        }]);
-        const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
-        const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
-        vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
-
-        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/approve', {
-            method: 'POST',
-            headers: { Authorization: 'Bearer valid.token' }
-        });
-
-        expect(res.status).toBe(403);
-    });
-    
-    it('should return 400 if submission is not pending or disputed', async () => {
-        const mockWhere = vi.fn().mockResolvedValue([{ 
-            submission: { id: 's-1', status: 'rejected' }, 
-            bounty: { id: 'b-1', creatorId: 'test-user-id' } 
-        }]);
-        const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
-        const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
-        vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
-
-        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/approve', {
-            method: 'POST',
-            headers: { Authorization: 'Bearer valid.token' }
-        });
-
-        expect(res.status).toBe(400);
-    });
-
-    it('should successfully approve submission and trigger payment', async () => {
-        const mockWhere = vi.fn().mockResolvedValue([{ 
-            submission: { id: '123e4567-e89b-12d3-a456-426614174000', status: 'pending', developerId: 'dev-1' }, 
-            bounty: { id: 'b-1', creatorId: 'test-user-id', amountUsdc: '100.00' } 
-        }]);
-        const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
-        const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
-        vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
-
-        const mockUpdateReturning = vi.fn().mockResolvedValue([{ id: '123e4567-e89b-12d3-a456-426614174000' }]);
-        const mockUpdateWhere = vi.fn().mockReturnValue({ returning: mockUpdateReturning });
-        const mockUpdateSet = vi.fn().mockReturnValue({ where: mockUpdateWhere });
-        const mockUpdate = vi.fn().mockReturnValue({ set: mockUpdateSet });
-
-        const mockInsertValues = vi.fn().mockResolvedValue([{ id: 'mock-tx-id' }]);
-        const mockInsert = vi.fn().mockReturnValue({ values: mockInsertValues });
-
-        db.transaction = vi.fn().mockImplementation(async (cb) => {
-            return cb({
-                update: mockUpdate,
-                insert: mockInsert
-            });
-        });
-
-        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/approve', {
-            method: 'POST',
-            headers: { Authorization: 'Bearer valid.token' }
-        });
-
-        expect(res.status).toBe(200);
-        const body = await res.json();
-        expect(body.message).toBe('Submission approved and payment triggered successfully');
-        
-        // Restore transaction
-        vi.restoreAllMocks();
-    });
-});
-
-describe('POST /api/submissions/:id/reject', () => {
-    let app: ReturnType<typeof createApp>;
-
-    beforeAll(() => {
-        app = createApp();
-        process.env.JWT_PUBLIC_KEY = '-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----';
-    });
-
-    beforeEach(() => {
-        vi.clearAllMocks();
-        vi.mocked(verify).mockResolvedValue({
-            sub: 'test-user-id',
-            id: 'test-user-id',
-            username: 'testuser',
-            exp: Math.floor(Date.now() / 1000) + 3600,
-        });
-    });
-
-    it('should return 401 if unauthorized', async () => {
-        vi.mocked(verify).mockRejectedValue(new Error('Invalid token'));
-
-        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/reject', {
-            method: 'POST',
-            headers: { Authorization: 'Bearer invalid.token', 'Content-Type': 'application/json' },
-            body: JSON.stringify({ rejection_reason: 'reason' })
-        });
-
-        expect(res.status).toBe(401);
-    });
-
-    it('should return 400 for missing rejection reason', async () => {
-        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/reject', {
-            method: 'POST',
-            headers: { Authorization: 'Bearer valid.token', 'Content-Type': 'application/json' },
-            body: JSON.stringify({})
-        });
-
-        expect(res.status).toBe(400);
-    });
-
-    it('should return 403 if user is not the bounty creator', async () => {
-        const mockWhere = vi.fn().mockResolvedValue([{ 
-            submission: { id: 's-1', status: 'pending' }, 
-            bounty: { id: 'b-1', creatorId: 'different-user' } 
-        }]);
-        const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
-        const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
-        vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
-
-        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/reject', {
-            method: 'POST',
-            headers: { Authorization: 'Bearer valid.token', 'Content-Type': 'application/json' },
-            body: JSON.stringify({ rejection_reason: 'reason' })
-        });
-
-        expect(res.status).toBe(403);
-    });
-
-    it('should successfully reject submission', async () => {
-        const mockWhere = vi.fn().mockResolvedValue([{ 
-            submission: { id: '123e4567-e89b-12d3-a456-426614174000', status: 'pending' }, 
-            bounty: { id: 'b-1', creatorId: 'test-user-id' } 
-        }]);
-        const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
-        const mockFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
-        vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
-
-        const mockUpdateReturning = vi.fn().mockResolvedValue([{ id: '123e4567-e89b-12d3-a456-426614174000' }]);
-        const mockUpdateWhere = vi.fn().mockReturnValue({ returning: mockUpdateReturning });
-        const mockUpdateSet = vi.fn().mockReturnValue({ where: mockUpdateWhere });
-        const mockUpdate = vi.fn().mockReturnValue({ set: mockUpdateSet });
-
-        db.transaction = vi.fn().mockImplementation(async (cb) => {
-            return cb({ update: mockUpdate });
-        });
-
-        const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/reject', {
-            method: 'POST',
-            headers: { Authorization: 'Bearer valid.token', 'Content-Type': 'application/json' },
-            body: JSON.stringify({ rejection_reason: 'Does not meet requirements.' })
-        });
-
-        expect(res.status).toBe(200);
-        const body = await res.json();
-        expect(body.message).toBe('Submission rejected successfully');
+nt POST /submissions/:id/dispute endpoint)
     });
 });

--- a/packages/api/src/__tests__/submissions.test.ts
+++ b/packages/api/src/__tests__/submissions.test.ts
@@ -279,7 +279,6 @@ nt POST /submissions/:id/dispute endpoint)
             method: 'POST',
             headers: {
                 Authorization: 'Bearer invalid.token',
-nt POST /submissions/:id/dispute endpoint)
         });
 
         expect(res.status).toBe(401);
@@ -291,14 +290,12 @@ nt POST /submissions/:id/dispute endpoint)
         expect(res.status).toBe(400);
     });
 
-nt POST /submissions/:id/dispute endpoint)
         vi.mocked(db.select).mockReturnValue({ from: mockFrom } as any);
 
         const res = await app.request('/api/submissions/123e4567-e89b-12d3-a456-426614174000/dispute', {
             method: 'POST',
             headers: {
                 Authorization: 'Bearer valid.token',
-nt POST /submissions/:id/dispute endpoint)
         });
 
         expect(res.status).toBe(404);
@@ -314,7 +311,6 @@ nt POST /submissions/:id/dispute endpoint)
             method: 'POST',
             headers: {
                 Authorization: 'Bearer valid.token',
-nt POST /submissions/:id/dispute endpoint)
         });
 
         expect(res.status).toBe(400);
@@ -327,11 +323,9 @@ nt POST /submissions/:id/dispute endpoint)
             method: 'POST',
             headers: {
                 Authorization: 'Bearer valid.token',
-nt POST /submissions/:id/dispute endpoint)
         });
 
         expect(res.status).toBe(409);
         const body = await res.json();
-nt POST /submissions/:id/dispute endpoint)
     });
 });

--- a/packages/api/src/routes/submissions.ts
+++ b/packages/api/src/routes/submissions.ts
@@ -204,6 +204,17 @@ submissionsRouter.post(
                 return { dispute, status: 201 };
             });
 
+            if ('error' in result) {
+                return c.json(
+                    {
+                        error: result.error,
+                        ...(result.disputeId && { disputeId: result.disputeId }),
+                        ...(result.currentStatus && { currentStatus: result.currentStatus })
+                    },
+                    result.status as 400 | 404 | 409
+                );
+            }
+
             return c.json({
                 data: result.dispute,
                 message: 'Dispute opened successfully',

--- a/packages/api/src/routes/submissions.ts
+++ b/packages/api/src/routes/submissions.ts
@@ -208,8 +208,8 @@ submissionsRouter.post(
                 return c.json(
                     {
                         error: result.error,
-                        ...(result.disputeId && { disputeId: result.disputeId }),
-                        ...(result.currentStatus && { currentStatus: result.currentStatus })
+                        ...('disputeId' in result && { disputeId: result.disputeId }),
+                        ...('currentStatus' in result && { currentStatus: result.currentStatus })
                     },
                     result.status as 400 | 404 | 409
                 );

--- a/packages/api/src/routes/submissions.ts
+++ b/packages/api/src/routes/submissions.ts
@@ -137,75 +137,93 @@ submissionsRouter.post(
         const { id } = c.req.valid('param');
         const { reason, evidenceLinks } = c.req.valid('json');
 
-        // Use transaction to ensure atomicity
-        const result = await db.transaction(async (tx) => {
-            // Check if submission exists and belongs to user
-            const [submission] = await tx
-                .select()
-                .from(submissions)
-                .where(and(
-                    eq(submissions.id, id),
-                    eq(submissions.developerId, user.id)
-                ));
+        try {
+            // Use transaction to ensure atomicity
+            const result = await db.transaction(async (tx) => {
+                // Check if submission exists and belongs to user
+                const [submission] = await tx
+                    .select()
+                    .from(submissions)
+                    .where(and(
+                        eq(submissions.id, id),
+                        eq(submissions.developerId, user.id)
+                    ));
 
-            if (!submission) {
-                return { error: 'Submission not found', status: 404 };
+                if (!submission) {
+                    return { error: 'Submission not found', status: 404 };
+                }
+
+                // Validate submission was rejected
+                if (submission.status !== 'rejected') {
+                    return {
+                        error: 'Only rejected submissions can be disputed',
+                        currentStatus: submission.status,
+                        status: 400
+                    };
+                }
+
+                // Check if dispute already exists
+                const [existingDispute] = await tx
+                    .select()
+                    .from(disputes)
+                    .where(eq(disputes.submissionId, id));
+
+                if (existingDispute) {
+                    return {
+                        error: 'Dispute already exists for this submission',
+                        disputeId: existingDispute.id,
+                        status: 409
+                    };
+                }
+
+                // Create dispute record
+                const [dispute] = await tx
+                    .insert(disputes)
+                    .values({
+                        submissionId: id,
+                        reason,
+                        evidenceLinks,
+                        status: 'open',
+                    })
+                    .returning();
+
+                // Update submission status to disputed with optimistic locking
+                const [updated] = await tx
+                    .update(submissions)
+                    .set({ status: 'disputed' })
+                    .where(and(
+                        eq(submissions.id, id),
+                        eq(submissions.status, 'rejected')
+                    ))
+                    .returning({ id: submissions.id });
+
+                if (!updated) {
+                    return {
+                        error: 'Submission was modified by another request. Please refresh and try again.',
+                        status: 409
+                    };
+                }
+
+                return { dispute, status: 201 };
+            });
+
+            if (result.error) {
+                return c.json(
+                    { error: result.error, disputeId: result.disputeId, currentStatus: result.currentStatus },
+                    result.status as 400 | 404 | 409
+                );
             }
 
-            // Validate submission was rejected
-            if (submission.status !== 'rejected') {
-                return {
-                    error: 'Only rejected submissions can be disputed',
-                    currentStatus: submission.status,
-                    status: 400
-                };
-            }
-
-            // Check if dispute already exists
-            const [existingDispute] = await tx
-                .select()
-                .from(disputes)
-                .where(eq(disputes.submissionId, id));
-
-            if (existingDispute) {
-                return {
-                    error: 'Dispute already exists for this submission',
-                    disputeId: existingDispute.id,
-                    status: 409
-                };
-            }
-
-            // Create dispute record
-            const [dispute] = await tx
-                .insert(disputes)
-                .values({
-                    submissionId: id,
-                    reason,
-                    evidenceLinks,
-                    status: 'open',
-                })
-                .returning();
-
-            // Update submission status to disputed
-            await tx
-                .update(submissions)
-                .set({ status: 'disputed' })
-                .where(eq(submissions.id, id));
-
-            return { dispute, status: 201 };
-        });
-
-        if (result.error) {
-            return c.json(
-                { error: result.error, disputeId: result.disputeId, currentStatus: result.currentStatus },
-                result.status as 400 | 404 | 409
-            );
+            return c.json({
+                data: result.dispute,
+                message: 'Dispute opened successfully',
+            }, 201);
+        } catch (error) {
+            console.error('Transaction failed:', error);
+            return c.json({
+                error: 'Failed to create dispute due to a database error. Please try again.'
+            }, 500);
         }
-
-        return c.json({
-            data: result.dispute,
-            message: 'Dispute opened successfully',
-        }, 201);
     }
 );
 

--- a/packages/api/src/routes/submissions.ts
+++ b/packages/api/src/routes/submissions.ts
@@ -119,9 +119,16 @@ submissionsRouter.get(
     }
 );
 
+
+const disputeSchema = z.object({
+    reason: z.string().min(1).max(2000),
+    evidenceLinks: z.array(z.string().url()).optional().default([]),
+});
+
 /**
  * POST /api/submissions/:id/dispute
- * Allows developer to dispute a rejected submission with reason and evidence_links
+ * Opens a dispute for a rejected submission.
+ * Validates that submission was rejected and belongs to the authenticated user.
  */
 submissionsRouter.post(
     '/:id/dispute',
@@ -134,57 +141,75 @@ submissionsRouter.post(
         }
 
         const { id } = c.req.valid('param');
-        const { reason, evidence_links } = c.req.valid('json');
+        const { reason, evidenceLinks } = c.req.valid('json');
 
-        const result = await db.select()
-            .from(submissions)
-            .where(and(eq(submissions.id, id), eq(submissions.developerId, user.id)));
-
-        if (result.length === 0) {
-            return c.json({ error: 'Submission not found' }, 404);
-        }
-
-        const submission = result[0];
-
-        if (submission.status !== 'rejected') {
-            return c.json({ error: 'Only rejected submissions can be disputed' }, 400);
-        }
-
-        // Check if a dispute already exists
-        const existingDisputes = await db.select()
-            .from(disputes)
-            .where(eq(disputes.submissionId, id));
-
-        if (existingDisputes.length > 0) {
-            return c.json({ error: 'A dispute already exists for this submission' }, 400);
-        }
-
-        // Use a transaction to mark the submission as disputed and record the dispute
         try {
             const [createdDispute] = await db.transaction(async (tx) => {
-                const updated = await tx.update(submissions)
-                    .set({ status: 'disputed' })
-                    .where(and(eq(submissions.id, id), eq(submissions.status, 'rejected')))
-                    .returning({ id: submissions.id });
+                // Check if submission exists and belongs to user
+                const [submission] = await tx
+                    .select()
+                    .from(submissions)
+                    .where(and(
+                        eq(submissions.id, id),
+                        eq(submissions.developerId, user.id)
+                    ));
 
-                if (updated.length === 0) {
+                if (!submission) {
                     tx.rollback();
+                    return c.json({ error: 'Submission not found' }, 404);
                 }
 
-                return await tx.insert(disputes).values({
-                    submissionId: id,
-                    reason,
-                    evidenceLinks: evidence_links,
-                    status: 'open'
-                }).returning();
+                // Validate submission was rejected
+                if (submission.status !== 'rejected') {
+                    tx.rollback();
+                    return c.json({
+                        error: 'Only rejected submissions can be disputed',
+                        currentStatus: submission.status
+                    }, 400);
+                }
+
+                // Check if dispute already exists
+                const [existingDispute] = await tx
+                    .select()
+                    .from(disputes)
+                    .where(eq(disputes.submissionId, id));
+
+                if (existingDispute) {
+                    tx.rollback();
+                    return c.json({
+                        error: 'Dispute already exists for this submission',
+                        disputeId: existingDispute.id
+                    }, 409);
+                }
+
+                // Update submission status to disputed
+                await tx
+                    .update(submissions)
+                    .set({ status: 'disputed' })
+                    .where(eq(submissions.id, id));
+
+                // Create dispute record
+                return await tx
+                    .insert(disputes)
+                    .values({
+                        submissionId: id,
+                        reason,
+                        evidenceLinks,
+                        status: 'open',
+                    })
+                    .returning();
             });
 
-            return c.json({ data: createdDispute }, 201);
+            return c.json({
+                data: createdDispute,
+                message: 'Dispute opened successfully',
+            }, 201);
         } catch (error) {
             return c.json({ error: 'Failed to create dispute or submission was modified concurrently' }, 409);
         }
     }
 );
+
 
 /**
  * POST /api/submissions/:id/approve
@@ -247,7 +272,7 @@ submissionsRouter.post(
                     bountyId: bounty.id,
                     status: 'pending'
                 });
-                
+
                 // Update the bounty status to completed
                 await tx.update(bounties)
                     .set({ status: 'completed' })
@@ -304,7 +329,7 @@ submissionsRouter.post(
         try {
             await db.transaction(async (tx) => {
                 const updated = await tx.update(submissions)
-                    .set({ 
+                    .set({
                         status: 'rejected',
                         rejectionReason: rejection_reason
                     })
@@ -313,7 +338,7 @@ submissionsRouter.post(
                         eq(submissions.status, submission.status)
                     ))
                     .returning({ id: submissions.id });
-                    
+
                 if (updated.length === 0) {
                     tx.rollback();
                 }

--- a/packages/api/src/routes/submissions.ts
+++ b/packages/api/src/routes/submissions.ts
@@ -198,21 +198,11 @@ submissionsRouter.post(
                     .returning({ id: submissions.id });
 
                 if (!updated) {
-                    return {
-                        error: 'Submission was modified by another request. Please refresh and try again.',
-                        status: 409
-                    };
+                    tx.rollback();
                 }
 
                 return { dispute, status: 201 };
             });
-
-            if (result.error) {
-                return c.json(
-                    { error: result.error, disputeId: result.disputeId, currentStatus: result.currentStatus },
-                    result.status as 400 | 404 | 409
-                );
-            }
 
             return c.json({
                 data: result.dispute,
@@ -221,8 +211,8 @@ submissionsRouter.post(
         } catch (error) {
             console.error('Transaction failed:', error);
             return c.json({
-                error: 'Failed to create dispute due to a database error. Please try again.'
-            }, 500);
+                error: 'Failed to create dispute or submission was modified concurrently'
+            }, 409);
         }
     }
 );

--- a/packages/api/src/routes/submissions.ts
+++ b/packages/api/src/routes/submissions.ts
@@ -18,8 +18,8 @@ const rejectSchema = z.object({
 });
 
 const disputeSchema = z.object({
-    reason: z.string().min(1, { message: 'Reason is required' }),
-    evidence_links: z.array(z.string().url()).optional(),
+    reason: z.string().min(1).max(2000),
+    evidenceLinks: z.array(z.string().url()).optional().default([]),
 });
 
 const idSchema = z.object({
@@ -119,12 +119,6 @@ submissionsRouter.get(
     }
 );
 
-
-const disputeSchema = z.object({
-    reason: z.string().min(1).max(2000),
-    evidence_links: z.array(z.string().url()).optional().default([]),
-});
-
 /**
  * POST /api/submissions/:id/dispute
  * Opens a dispute for a rejected submission.
@@ -141,11 +135,79 @@ submissionsRouter.post(
         }
 
         const { id } = c.req.valid('param');
-        const { reason, evidence_links } = c.req.valid('json');
+        const { reason, evidenceLinks } = c.req.valid('json');
 
+        // Use transaction to ensure atomicity
+        const result = await db.transaction(async (tx) => {
+            // Check if submission exists and belongs to user
+            const [submission] = await tx
+                .select()
+                .from(submissions)
+                .where(and(
+                    eq(submissions.id, id),
+                    eq(submissions.developerId, user.id)
+                ));
+
+            if (!submission) {
+                return { error: 'Submission not found', status: 404 };
+            }
+
+            // Validate submission was rejected
+            if (submission.status !== 'rejected') {
+                return {
+                    error: 'Only rejected submissions can be disputed',
+                    currentStatus: submission.status,
+                    status: 400
+                };
+            }
+
+            // Check if dispute already exists
+            const [existingDispute] = await tx
+                .select()
+                .from(disputes)
+                .where(eq(disputes.submissionId, id));
+
+            if (existingDispute) {
+                return {
+                    error: 'Dispute already exists for this submission',
+                    disputeId: existingDispute.id,
+                    status: 409
+                };
+            }
+
+            // Create dispute record
+            const [dispute] = await tx
+                .insert(disputes)
+                .values({
+                    submissionId: id,
+                    reason,
+                    evidenceLinks,
+                    status: 'open',
+                })
+                .returning();
+
+            // Update submission status to disputed
+            await tx
+                .update(submissions)
+                .set({ status: 'disputed' })
+                .where(eq(submissions.id, id));
+
+            return { dispute, status: 201 };
+        });
+
+        if (result.error) {
+            return c.json(
+                { error: result.error, disputeId: result.disputeId, currentStatus: result.currentStatus },
+                result.status as 400 | 404 | 409
+            );
+        }
+
+        return c.json({
+            data: result.dispute,
+            message: 'Dispute opened successfully',
+        }, 201);
     }
 );
-
 
 /**
  * POST /api/submissions/:id/approve

--- a/packages/api/src/routes/submissions.ts
+++ b/packages/api/src/routes/submissions.ts
@@ -122,7 +122,7 @@ submissionsRouter.get(
 
 const disputeSchema = z.object({
     reason: z.string().min(1).max(2000),
-    evidenceLinks: z.array(z.string().url()).optional().default([]),
+    evidence_links: z.array(z.string().url()).optional().default([]),
 });
 
 /**
@@ -141,72 +141,8 @@ submissionsRouter.post(
         }
 
         const { id } = c.req.valid('param');
-        const { reason, evidenceLinks } = c.req.valid('json');
+        const { reason, evidence_links } = c.req.valid('json');
 
-        try {
-            const [createdDispute] = await db.transaction(async (tx) => {
-                // Check if submission exists and belongs to user
-                const [submission] = await tx
-                    .select()
-                    .from(submissions)
-                    .where(and(
-                        eq(submissions.id, id),
-                        eq(submissions.developerId, user.id)
-                    ));
-
-                if (!submission) {
-                    tx.rollback();
-                    return c.json({ error: 'Submission not found' }, 404);
-                }
-
-                // Validate submission was rejected
-                if (submission.status !== 'rejected') {
-                    tx.rollback();
-                    return c.json({
-                        error: 'Only rejected submissions can be disputed',
-                        currentStatus: submission.status
-                    }, 400);
-                }
-
-                // Check if dispute already exists
-                const [existingDispute] = await tx
-                    .select()
-                    .from(disputes)
-                    .where(eq(disputes.submissionId, id));
-
-                if (existingDispute) {
-                    tx.rollback();
-                    return c.json({
-                        error: 'Dispute already exists for this submission',
-                        disputeId: existingDispute.id
-                    }, 409);
-                }
-
-                // Update submission status to disputed
-                await tx
-                    .update(submissions)
-                    .set({ status: 'disputed' })
-                    .where(eq(submissions.id, id));
-
-                // Create dispute record
-                return await tx
-                    .insert(disputes)
-                    .values({
-                        submissionId: id,
-                        reason,
-                        evidenceLinks,
-                        status: 'open',
-                    })
-                    .returning();
-            });
-
-            return c.json({
-                data: createdDispute,
-                message: 'Dispute opened successfully',
-            }, 201);
-        } catch (error) {
-            return c.json({ error: 'Failed to create dispute or submission was modified concurrently' }, 409);
-        }
     }
 );
 


### PR DESCRIPTION
## Summary
Implements the dispute functionality for rejected submissions, addressing issue #29.

## Changes
- **New Endpoint**: POST /api/submissions/:id/dispute
- **Validation**: Ensures submission exists, belongs to user, and was rejected
- **Duplicate Prevention**: Returns 409 if dispute already exists
- **Status Update**: Changes submission status to 'disputed' on success

## API
```http
POST /api/submissions/:id/dispute
Content-Type: application/json

{
  "reason": "The rejection was incorrect because...",
  "evidenceLinks": ["https://example.com/proof"]
}
```

## Response
- 201: Dispute created successfully
- 400: Submission not rejected or validation error
- 404: Submission not found
- 409: Dispute already exists

## Testing
- Added comprehensive test suite for all scenarios
- Tests cover auth, validation, edge cases

Closes #29